### PR TITLE
cleanup the .DS_Store files and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.env


### PR DESCRIPTION
### Problem
We're checking in a bunch of these files https://en.wikipedia.org/wiki/.DS_Store that are gen'ed by macos 

### Solution
Rather than play whack-o-mole lets have [git just ignore](https://help.github.com/en/github/using-git/ignoring-files) them so they don't get checked into our branches and therefore the `assignments-2019` repo

Adding `.env` b/c it seems like a good idea